### PR TITLE
Dropdown multiple shadow dom fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject velho-ds "0.0.0.22"
+(defproject velho-ds "0.0.0.22-jaakko"
   :description "Velho Allianssi Design System"
   :url "https://github.com/trinne/velho-ds"
   :license {:name "Eclipse Public License"
@@ -17,7 +17,7 @@
                  [reagent "0.7.0" :exclusions [cljsjs/react]]
                  [cljsjs/react-with-addons "15.6.1-0"]
                  [cljsjs/react-dom "15.6.1-0" :exclusions [cljsjs/react]]
-                 [stylefy "1.7.0"]
+                 [stylefy "1.9.0"]
                  [bidi "2.1.3"]
                  [venantius/accountant "0.2.4"]
                  [reagent-utils "0.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject velho-ds "0.0.0.22"
+(defproject velho-ds "0.0.0.23"
   :description "Velho Allianssi Design System"
   :url "https://github.com/trinne/velho-ds"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject velho-ds "0.0.0.22-jaakko"
+(defproject velho-ds "0.0.0.22"
   :description "Velho Allianssi Design System"
   :url "https://github.com/trinne/velho-ds"
   :license {:name "Eclipse Public License"

--- a/src/cljs/velho_ds/core.cljs
+++ b/src/cljs/velho_ds/core.cljs
@@ -67,7 +67,7 @@
   (r/render [page [navigation (last routes)]] (.getElementById js/document "app")))
 
 (defn init! []
-  (design-system/init-ds!)
+  (design-system/init-ds! (.getElementById js/document "app"))
   (accountant/configure-navigation! {:nav-handler navigate :path-exists? path-exists?})
   (accountant/dispatch-current!)
   (mount-root))

--- a/src/cljs/velho_ds/design_system.cljs
+++ b/src/cljs/velho_ds/design_system.cljs
@@ -1,5 +1,8 @@
 (ns velho-ds.design-system
   (:require [stylefy.core :as stylefy]))
 
-(defn init-ds! []
-  (stylefy/init {:use-caching? false}))
+(def root-element (atom nil))
+(defn init-ds! [dom-element]
+  (reset! root-element dom-element)
+  (stylefy/init {:use-caching? false
+                 :multi-instance {:base-node @root-element}}))

--- a/src/cljs/velho_ds/molecules/field.cljs
+++ b/src/cljs/velho_ds/molecules/field.cljs
@@ -263,13 +263,6 @@
     [icons/clickable {:name "arrow_drop_down"
                       :styles style/dropdown-icon}]]])
 
-(defn- click-in-dropdown? [element id]
-  (if (nil? element)
-    false
-    (if (= id (.-id element))
-        true
-        (click-in-dropdown? (.-parentElement element) id))))
-
 (defn dropdown-multiple [{:keys [label placeholder selected-fn options preselected-values]}]
   (assert (fn? selected-fn) ":selected-fn function is required for dropdown-multiple")
   (assert (vector? options) ":options vector is required for dropdown-multiple")
@@ -314,6 +307,12 @@
                                  (swap! state assoc :selected-from-filter ""))
                                (when (= key "Tab")
                                  (swap! state assoc :focus false)))
+        click-in-dropdown? (fn click-in-dropdown? [element id]
+                             (if (nil? element)
+                               false
+                               (if (= id (.-id element))
+                                 true
+                                 (click-in-dropdown? (.-parentElement element) id))))
         global-click-handler #(let [target (.-target %)]
                                 (when-not (click-in-dropdown? target @dropdown-id)
                                   (swap! state assoc :focus false)))]

--- a/src/cljs/velho_ds/molecules/field.cljs
+++ b/src/cljs/velho_ds/molecules/field.cljs
@@ -191,7 +191,7 @@
     (fn [{:keys [item-list icon error-messages]}]
       (reset! item-list-keys (create-keys item-list))
       [:div.vds-input-field (stylefy/use-style styles {:class (str "dropdown-menu-" (:id @state))})
-       [:label.seppio (stylefy/use-style style/element {:class (str "dropdown-menu-" (:id @state))})
+       [:label (stylefy/use-style style/element {:class (str "dropdown-menu-" (:id @state))})
         (into [:div (stylefy/use-style (merge style/dropdown-list-container
                                               {:display (if (:focus @state) "block" "none")})
                                        {:class (str "dropdown-menu-" (:id @state))})]

--- a/src/cljs/velho_ds/molecules/field.cljs
+++ b/src/cljs/velho_ds/molecules/field.cljs
@@ -336,7 +336,6 @@
                             [:input (stylefy/use-style style/dropdown-multiple-input {:type "text"
                                                                                       :on-change #(-> % .-target .-value input-value-changed-fn)
                                                                                       :on-key-down #(-> % .-key key-press-handler-fn)
-                                                                                      :on-focus #(swap! state assoc :focus true)
                                                                                       :value (:input-text @state)
                                                                                       :placeholder placeholder})]
                             [icons/clickable {:name (if (:focus @state) "arrow_drop_up" "arrow_drop_down")

--- a/src/cljs/velho_ds/molecules/field.cljs
+++ b/src/cljs/velho_ds/molecules/field.cljs
@@ -15,8 +15,11 @@
   ([element event func]
    (dommy/listen! element event func)))
 
-(defn- remove-event-listener [event func]
-  (dommy/unlisten! @ds/root-element event func))
+(defn- remove-event-listener
+  ([event func]
+   (remove-event-listener @ds/root-element event func))
+  ([element event func]
+   (dommy/unlisten! element event func)))
 
 (defn- search-in-list [collection search-word]
   (filter #(string/includes? (string/lower-case %) search-word) collection))

--- a/src/cljs/velho_ds/molecules/modal.cljs
+++ b/src/cljs/velho_ds/molecules/modal.cljs
@@ -19,7 +19,7 @@
 
 (defn default [{:keys [header header-buttons content footer is-open]}]
   [:div (if is-open (stylefy/use-style style/modal-area)
-                    (stylefy/use-style (merge style/modal-area {:display "none"})) )
+                    (stylefy/use-style (merge style/modal-area {:display "none"})))
    [:div (stylefy/use-style style/background)]
    [:div (stylefy/use-style style/modal-box)
     [:header (stylefy/use-style style/modal-header)


### PR DESCRIPTION
Fixed dropdown-multiple to work with shadow dom. Focus event doesn't bubble and is not received by react. Now the event handler is added to input element to receive the event correctly.