### PR TITLE
Prevent drag and drop on modal background. Change color to solid when

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject velho-ds "0.0.0.54"
+(defproject velho-ds "0.0.0.57"
   :description "Velho Allianssi Design System"
   :url "https://github.com/velho-allianssi/velho-ds"
   :license {:name "Eclipse Public License"

--- a/src/cljs/velho_ds/molecules/modal.cljs
+++ b/src/cljs/velho_ds/molecules/modal.cljs
@@ -4,10 +4,17 @@
             [reagent.core :as r]))
 
 (defn wrapper [& content]
-  [:div (stylefy/use-style style/fade)
-   [:div (stylefy/use-style style/wrapper)
-    [:div (stylefy/use-style style/bg)
-     (map-indexed #(with-meta %2 {:key %1}) content)]]])
+  (let [drag (r/atom false)
+        events {:on-drop #(do (reset! drag false) (.preventDefault %))
+                :on-drag-leave #(reset! drag false)
+                :on-drag-over #(do (reset! drag true) (.preventDefault %))}
+        fade style/fade
+        solid (merge fade {:background "hsla(0, 0%, 20%, 1)"})]
+    (fn []
+      [:div (stylefy/use-style (if @drag solid fade) events)
+       [:div (stylefy/use-style style/wrapper)
+        [:div (stylefy/use-style style/bg)
+         (map-indexed #(with-meta %2 {:key %1}) content)]]])))
 
 (defn header [otsikko & ikoni]
   [:header (stylefy/use-style style/header)


### PR DESCRIPTION
drag starts so that chrome doesn't capture dnd events in any background
iframes.