### PR TITLE
Make the breadcrumbs to be able to show ellipses on overflow 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject velho-ds "0.0.0.58"
+(defproject velho-ds "0.0.0.59"
   :description "Velho Allianssi Design System"
   :url "https://github.com/velho-allianssi/velho-ds"
   :license {:name "Eclipse Public License"

--- a/src/cljs/velho_ds/molecules/field.cljs
+++ b/src/cljs/velho_ds/molecules/field.cljs
@@ -591,12 +591,15 @@
                         (recur (:child page)))))]
     (get-pages current-page)
     (fn []
-      [:div
+      [:div {:style {:display "flex"
+                     :overflow "hidden"
+                     :align-items "center"}}
        (for [page (butlast @pages)]
-         ^{:key page} [:span
+         ^{:key page} [:span {:style {:overflow "hidden"
+                                      :display "flex"
+                                      :align-items "center"}}
                        [:a {:on-click #(when click-fn (click-fn page))
                             :style style/breadcrumb} (:label page)]
                        [:h2 {:style style/breadcrumb-breaker} "/"]])
-       [:span {:style {:display "inline-block"}}
-        [:h2 (stylefy/use-style style/breadcrumb-current-page) (:label (last @pages))]
-        (map-indexed #(with-meta %2 {:key %1}) content)]])))
+       [:h2 (stylefy/use-style style/breadcrumb-current-page) (:label (last @pages))]
+       (map-indexed #(with-meta %2 {:key %1}) content)])))

--- a/src/cljs/velho_ds/molecules/style/field.cljs
+++ b/src/cljs/velho_ds/molecules/style/field.cljs
@@ -314,16 +314,21 @@
    :margin 0
    :color color/color-neutral-4})
 
+(def ellipsis
+  {:white-space "nowrap"
+   :overflow "hidden"
+   :text-overflow "ellipsis"})
+
 (def breadcrumb
-  {:text-decoration "none"
-   :margin 0
-   :cursor "pointer"
-   :color color/color-primary-dark
-   :display "inline-block"
-   :font-family font/font-family-heading
-   :font-size font-size/font-size-x-large
-   :font-weight font/font-weight-light
-   :line-height line-height/line-height-heading})
+  (merge ellipsis {:text-decoration "none"
+                   :margin          0
+                   :cursor          "pointer"
+                   :color           color/color-primary-dark
+                   :display         "inline"
+                   :font-family     font/font-family-heading
+                   :font-size       font-size/font-size-x-large
+                   :font-weight     font/font-weight-light
+                   :line-height     line-height/line-height-heading}))
 
 (def breadcrumb-breaker
   {:margin 0
@@ -332,7 +337,7 @@
    :line-height spacing/space-base-rem})
 
 (def breadcrumb-current-page
-  {:margin 0
-   :display "inline-block"
-   :padding-right "0"
-   :line-height spacing/space-base-rem})
+  (merge ellipsis {:margin        0
+                   :display       "inline"
+                   :padding-right "0"
+                   :line-height   spacing/space-base-rem}))


### PR DESCRIPTION
Changed breadcrumbs styles and structure so that it is able to cut text and show ellipses insted of overflowing out of the layout.